### PR TITLE
Added Python requirements file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python
+pillow


### PR DESCRIPTION
When I used "img2img.py" and "img2txt.py" for the first time, Python complained about modules that it could not import. To solve that problem, I created a "requirements.txt" file.

To install requirements, you can simply run:
pip install -r requirements.txt

Afterwards, both "img2img.py" and "img2txt.py" worked well for me.